### PR TITLE
Zabbix MariaDB support YES

### DIFF
--- a/list-dba.md
+++ b/list-dba.md
@@ -86,7 +86,7 @@ Articles:
 | [PMM](https://docs.percona.com/percona-monitoring-and-management/)  | YES                                                         | [AGPL3](https://github.com/percona/pmm/blob/main/LICENSE) or cloud   | [1]     |
 | [SolarWinds](https://www.solarwinds.com/)                           | YES                                                         | Commercial in-premise or cloud                             |         |
 | [SSM](https://shatteredsilicon.net/mysql-monitoring-ssm/)           | YES                                                         | Open source                                                | [2]     |
-| [Zabbix](https://www.zabbix.com/)                                | [NOT VERIFIED](https://www.zabbix.com/documentation/current/en/manual/installation/best_practices/access_control/mysql)                         | [AGPL3](https://github.com/zabbix/zabbix/blob/master/COPYING)   |         |
+| [Zabbix](https://www.zabbix.com/)                                | YES                         | [AGPL3](https://github.com/zabbix/zabbix/blob/master/COPYING)   |         |
 
 1. See the [online demo](https://pmmdemo.percona.com).
 2. PMM v1 fork.

--- a/list-dba.md
+++ b/list-dba.md
@@ -88,10 +88,11 @@ Articles:
 | [PMM](https://docs.percona.com/percona-monitoring-and-management/)  | YES                                                         | [AGPL3](https://github.com/percona/pmm/blob/main/LICENSE) or cloud   | [1]     |
 | [SolarWinds](https://www.solarwinds.com/)                           | YES                                                         | Commercial in-premise or cloud                             |         |
 | [SSM](https://shatteredsilicon.net/mysql-monitoring-ssm/)           | YES                                                         | Open source                                                | [2]     |
-| [Zabbix](https://www.zabbix.com/)                                | YES                         | [AGPL3](https://github.com/zabbix/zabbix/blob/master/COPYING)   |         |
+| [Zabbix](https://www.zabbix.com/)                                | YES                         | [AGPL3](https://github.com/zabbix/zabbix/blob/master/COPYING)   | [3]
 
 1. See the [online demo](https://pmmdemo.percona.com).
 2. PMM v1 fork.
+3. See [agent gathering MariaDB metrics](https://www.zabbix.com/integrations/mysql)
 
 ## Proxies
 


### PR DESCRIPTION
Suggesting Zabbix be changed from NOT VERIFIED to YES, as 
1) The requirements page ([zabbix.com/documentation/7.0/en/manual/installation/requirements?hl=MariaDB](https://www.zabbix.com/documentation/7.0/en/manual/installation/requirements?hl=MariaDB)) mentions MariaDB separately with comments about versions (10.5.00-11.4.X) and more. 
2) The installations best practises page [zabbix.com/documentation/current/en/manual/installation/best_practices/access_control/mysql](https://www.zabbix.com/documentation/current/en/manual/installation/best_practices/access_control/mysql) that was previously linked to from "NOT VERIFIED", does have MariaDB specific comments in it. 

So Zabbix does meet the YES-critierias? 