### PR TITLE
Schema Versioning Tools: tweak Skeema listing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ If you contribute to Awesome MariaDB, we encourage you to add your name here.
 - Laurynas Biveinis https://of-code.blogspot.com
 - Daniel Black https://mariadb.org
 - Daniël van Eeden https://databaseblog.myname.nl
+- Evan Elias https://www.skeema.io

--- a/list-dba.md
+++ b/list-dba.md
@@ -149,7 +149,7 @@ The following projects are either sharding components or sub-components that be 
 | [ByteBase](https://www.bytebase.com/)                   | [10.7+](https://www.bytebase.com/docs/introduction/supported-databases/) | Open source, proprietary, cloud |
 | [Flyway](https://flywaydb.org/)                         | [5.1, 10.11](https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases/mariadb) | [Apache 2](https://github.com/flyway/flyway/blob/main/LICENSE.txt) |
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
-| [Skeema.io](https://www.skeema.io/)                     | [10.1](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
+| [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 ## Security
 

--- a/list-dev.md
+++ b/list-dev.md
@@ -272,7 +272,7 @@ Links to articles and information on the various methods and utilities to read a
 | [ChronoVoyage](https://pypi.org/project/chronovoyage/)  | YES | MIT |
 | [Flyway](https://flywaydb.org/)                         | [5.1, 10.11](https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases/mariadb) | [Apache 2](https://github.com/flyway/flyway/blob/main/LICENSE.txt) |
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
-| [Skeema.io](https://www.skeema.io/)                     | [10.1](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
+| [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 
 ## Stored Routines


### PR DESCRIPTION
Thank you for including Skeema here! This pull request just makes a couple fixes to the listing:

* Name of the tool is simply Skeema (whereas skeema.io is the website/domain)

* Skeema supports MariaDB 10.1 *and up*, not just 10.1. Each new GA release of MariaDB Server is tested against, and supported in the subsequent Skeema release at a very fine-grained level. For example, Skeema's linter is aware that inet4 columns can be safely converted to inet6 columns only in MariaDB 11.3+, timestamp columns have a Y2K38 problem prior to MariaDB 11.5, etc. :)