### PR TITLE
Add SchemaSmith to Schema Versioning

### DIFF
--- a/list-dba.md
+++ b/list-dba.md
@@ -230,6 +230,7 @@ The following projects are either sharding components or sub-components that be 
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
 | [migrate](https://github.com/golang-migrate/migrate)    | YES             | [MIT](https://github.com/golang-migrate/migrate/blob/master/LICENSE) |
 | [Prisma Migrate](https://github.com/prisma/prisma)      | YES             | [Apache 2](https://github.com/prisma/prisma/blob/main/LICENSE) |
+| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.6+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
 | [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 ## Security

--- a/list-dev.md
+++ b/list-dev.md
@@ -400,6 +400,7 @@ Links to articles and information on the various methods and utilities to read a
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
 | [migrate](https://github.com/golang-migrate/migrate)    | YES             | [MIT](https://github.com/golang-migrate/migrate/blob/master/LICENSE) |
 | [Prisma Migrate](https://github.com/prisma/prisma)      | YES             | [Apache 2](https://github.com/prisma/prisma/blob/main/LICENSE) |
+| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.6+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
 | [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 


### PR DESCRIPTION
Adds [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) to the **Schema Versioning** tables in both `list-dba.md` and `list-dev.md`.

SchemaSmith is a free, source-available (SSCL v2.0) state-based schema management toolset with first-class MariaDB support (10.6+). Declare the desired database state as metadata and it transforms any target to match — no ordered migration scripts. Also supports SQL Server, PostgreSQL, and MySQL; cross-platform (Windows/Linux/macOS).

Placed alphabetically; followed the existing table format (Project Name | MariaDB Support | License / Platform).