### PR TITLE
Add Mongrel to GUI tables

### DIFF
--- a/inc/user-interfaces
+++ b/inc/user-interfaces
@@ -12,6 +12,7 @@
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
+| [Mongrel](https://www.visorcraft.com/mongrel)                               | [MySQL](https://www.visorcraft.com/mysql)       | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |

--- a/list-dba.md
+++ b/list-dba.md
@@ -302,7 +302,7 @@ Legacy engines are not included in this list.
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
-| [Mongrel](https://www.visorcraft.com/)                                       | [NOT VERIFIED](https://www.visorcraft.com/mysql) | Linux, MacOS, Windows | Proprietary     |       |
+| [Mongrel](https://www.visorcraft.com/mongrel)                               | [MySQL](https://www.visorcraft.com/mysql)       | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |

--- a/list-dba.md
+++ b/list-dba.md
@@ -302,6 +302,7 @@ Legacy engines are not included in this list.
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
+| [Mongrel](https://www.visorcraft.com/)                                       | [NOT VERIFIED](https://www.visorcraft.com/mysql) | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |

--- a/list-den.md
+++ b/list-den.md
@@ -188,6 +188,7 @@ The following resources show how to integrate MariaDB with various other data te
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
+| [Mongrel](https://www.visorcraft.com/mongrel)                               | [MySQL](https://www.visorcraft.com/mysql)       | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |

--- a/list-dev.md
+++ b/list-dev.md
@@ -540,6 +540,7 @@ Frameworks and libraries to ease UDFs developing.
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
+| [Mongrel](https://www.visorcraft.com/)                                       | [NOT VERIFIED](https://www.visorcraft.com/mysql) | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |

--- a/list-dev.md
+++ b/list-dev.md
@@ -540,7 +540,7 @@ Frameworks and libraries to ease UDFs developing.
 | [Harlequin](https://harlequin.sh/)                                          | MySQL                                           | Python                | Open Source          |       |
 | [HeidiSQL](https://www.heidisql.com/)                                       | YES                                              | Windows               | Open Source         |       |
 | [LibreOffice Base](https://www.libreoffice.org/discover/base/)              | [NOT VERIFIED](https://www.libreoffice.org/discover/base/) | Linux, MacOS, Windows | Open Source      | [1]   |
-| [Mongrel](https://www.visorcraft.com/)                                       | [NOT VERIFIED](https://www.visorcraft.com/mysql) | Linux, MacOS, Windows | Proprietary     |       |
+| [Mongrel](https://www.visorcraft.com/mongrel)                               | [MySQL](https://www.visorcraft.com/mysql)       | Linux, MacOS, Windows | Proprietary     |       |
 | [Navicat](https://www.navicat.com/)                                         | [YES]([https://www.navicat.com/en/products/navicat-for-mysql-feature-matrix](https://navicat.com/en/products/navicat-for-mariadb))   | Linux, MacOS, Windows | Proprietary |       |
 | [ocelotgui](http://ocelot.ca/)                                              | YES                                             | Linux                 | Open Source          |       |
 | [OpenOffice Base](https://www.openoffice.org/product/base.html)             | [MySQL](https://www.openoffice.org/product/base.html) | Linux, MacOS, Windows | Open Source           | [2]   |


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/) to the GUI tables in `list-dev.md` and `list-dba.md`.

Mongrel is a proprietary desktop database workbench (Linux, macOS, Windows) that includes MySQL/MariaDB support. MariaDB support is marked `NOT VERIFIED` with a link to the MySQL/MariaDB product page, matching other entries that document MySQL-family support without a dedicated MariaDB verification write-up.

Homepage only.