### PR TITLE
SchemaSmith: MariaDB minimum is now 10.2, not 10.6

### DIFF
--- a/list-dba.md
+++ b/list-dba.md
@@ -231,7 +231,7 @@ The following projects are either sharding components or sub-components that be 
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
 | [migrate](https://github.com/golang-migrate/migrate)    | YES             | [MIT](https://github.com/golang-migrate/migrate/blob/master/LICENSE) |
 | [Prisma Migrate](https://github.com/prisma/prisma)      | YES             | [Apache 2](https://github.com/prisma/prisma/blob/main/LICENSE) |
-| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.6+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
+| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.2+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
 | [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 ## Security

--- a/list-dev.md
+++ b/list-dev.md
@@ -400,7 +400,7 @@ Links to articles and information on the various methods and utilities to read a
 | [Liquibase](https://www.liquibase.com/)                 | [PARTIAL](https://www.liquibase.com/databases/mariadb-server) | [Proprietary](https://www.liquibase.com/pricing) or [Apache 2](https://github.com/liquibase/liquibase/blob/master/LICENSE.txt) |
 | [migrate](https://github.com/golang-migrate/migrate)    | YES             | [MIT](https://github.com/golang-migrate/migrate/blob/master/LICENSE) |
 | [Prisma Migrate](https://github.com/prisma/prisma)      | YES             | [Apache 2](https://github.com/prisma/prisma/blob/main/LICENSE) |
-| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.6+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
+| [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) | 10.2+ | Source available ([SSCL v2.0](https://github.com/Schema-Smith/SchemaSmith/blob/main/LICENSE)) |
 | [Skeema](https://www.skeema.io/)                     | [10.1+](https://www.skeema.io/docs/requirements/) | [Proprietary](https://www.skeema.io/download/) or [Apache 2](https://github.com/skeema/skeema/blob/main/LICENSE) |
 
 


### PR DESCRIPTION
Small correction to the SchemaSmith rows I added in #45.

Both entries list the MariaDB minimum as `10.6+`. That was accurate when submitted, but SchemaSmith lowered its supported floor to **MariaDB 10.2** in its v2.4.0 release, and v2.5.0 (released today) keeps it there. The listing currently understates supported versions by two releases.

Updated in both files, since the entry appears in each:

- `list-dba.md`
- `list-dev.md`

Reference: the supported-version table in the project README — https://github.com/Schema-Smith/SchemaSmith#readme — lists MariaDB 10.2 alongside SQL Server 2008, PostgreSQL 12 and MySQL 5.7. The floor is enforced at runtime from the detected server version.

Nothing else about the entries changes — same link, same license label.